### PR TITLE
fix: sort points before evaluate interpolation

### DIFF
--- a/src/application/numerical_method/views/lagrange_view.py
+++ b/src/application/numerical_method/views/lagrange_view.py
@@ -53,15 +53,16 @@ class LagrangeView(TemplateView):
         x_values = response_validation[0]
         y_values = response_validation[1]
 
+        # Ordenar puntos para la representación gráfica
+        points = list(zip(x_values, y_values))
+        sorted_points = sorted(points, key=lambda point: point[0])
+        
         # Ejecutar el método de Lagrange
         method_response = self.method_service.solve(
             x=x_values,
             y=y_values,
         )
 
-        # Ordenar puntos para la representación gráfica
-        points = list(zip(x_values, y_values))
-        sorted_points = sorted(points, key=lambda point: point[0])
 
         if method_response["is_successful"]:
             # Graficar la función interpolante

--- a/src/application/numerical_method/views/newton_interpol_view.py
+++ b/src/application/numerical_method/views/newton_interpol_view.py
@@ -48,14 +48,14 @@ class NewtonInterpolView(TemplateView):
 
         x_values = response_validation[0]
         y_values = response_validation[1]
+        points = list(zip(x_values, y_values))
+        sorted_points = sorted(points, key=lambda point: point[0])
 
         method_response = self.method_service.solve(
             x=x_values,
             y=y_values,
         )
 
-        points = list(zip(x_values, y_values))
-        sorted_points = sorted(points, key=lambda point: point[0])
 
         if method_response["is_successful"]:
             plot_function(

--- a/src/application/numerical_method/views/vandermonde_view.py
+++ b/src/application/numerical_method/views/vandermonde_view.py
@@ -48,14 +48,14 @@ class VandermondeView(TemplateView):
 
         x_values = response_validation[0]
         y_values = response_validation[1]
+        points = list(zip(x_values, y_values))
+        sorted_points = sorted(points, key=lambda point: point[0])
 
         method_response = self.method_service.solve(
             x=x_values,
             y=y_values,
         )
 
-        points = list(zip(x_values, y_values))
-        sorted_points = sorted(points, key=lambda point: point[0])
 
         if method_response["is_successful"]:
             plot_function(


### PR DESCRIPTION
## Description 
This PR adds function to sort input elements on interpolation methods (vandermonde, newton, lagrange).

## Checklist

- [x] This is not a duplicate of an existing pull request.
- [x] No existing features have been broken without good reason.
- [x] The code style guidelines have been followed.
- [x] The programming rules have been followed.